### PR TITLE
Add scientific notation to the Lexer

### DIFF
--- a/Lexer.js
+++ b/Lexer.js
@@ -115,6 +115,7 @@ define(["utils", "Token", "PascalError"], function (utils, Token, PascalError) {
                 // part of this token anymore.
                 var value = "";
                 var sawDecimalPoint = ch === ".";
+                var sawExp = ch === 'E';
                 while (true) {
                     value += ch;
                     ch = this.stream.peek();
@@ -139,10 +140,23 @@ define(["utils", "Token", "PascalError"], function (utils, Token, PascalError) {
                             // Allow one decimal point.
                             sawDecimalPoint = true;
                         }
+                    }else if(ch.toLowerCase() === 'e'){
+                        value += this.stream.next();
+                        nextCh = this.stream.peek();
+                        if(nextCh === '+' || nextCh === '-' || utils.isDigit(nextCh))
+                            value += this.stream.next();
+                        else
+                            throw new Error('Unexpected character ' + nextCh + ' while reading exponential form');
+                        while (true){
+                            nextCh = this.stream.peek();
+                            if(utils.isDigit(nextCh))
+                                value += this.stream.next();
+                            else
+                                return new Token(parseFloat(value).toString(), Token.NUMBER);
+                        }
                     } else if (!utils.isDigit(ch)) {
                         break;
                     }
-                    // XXX Need to parse scientific notation.
                     this.stream.next();
                 }
                 token = new Token(value, Token.NUMBER);


### PR DESCRIPTION
I think what i did is self-explanatory, we keep getting characters until we bump into an e, the we check if the next characters is allowed (i.e is +, - or simply a number), and then we keep getting numbers, if the nextCh is not a number then we return a tokens whose value is the scientific notation translated into a real type
Would it be a good idea if 0xab2 and 0b10101 also translated this way ?